### PR TITLE
Use Python 3.13 and cache transformer

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -1,4 +1,4 @@
-# This workflow will install Python dependencies, run tests and lint with a variety of Python versions
+# This workflow installs dependencies, runs tests, and lints the codebase
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
 
 name: Python package
@@ -13,27 +13,33 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: ["3.11", "3.12"]
 
     steps:
     - uses: actions/checkout@v3
-    - name: Set up Python ${{ matrix.python-version }}
+    - name: Set up Python
       uses: actions/setup-python@v3
       with:
-        python-version: ${{ matrix.python-version }}
+        python-version: "3.13"
     - name: Cache NLTK data
       uses: actions/cache@v4
       with:
         path: ~/nltk_data
-        key: ${{ runner.os }}-nltk-${{ matrix.python-version }}-${{ hashFiles('requirements.txt') }}
+        key: ${{ runner.os }}-nltk-3.13-${{ hashFiles('requirements.txt') }}
         restore-keys: |
-          ${{ runner.os }}-nltk-${{ matrix.python-version }}-
+          ${{ runner.os }}-nltk-3.13-
           ${{ runner.os }}-nltk-
+    - name: Cache sentence-transformers model
+      uses: actions/cache@v4
+      with:
+        path: ~/.cache/torch/sentence_transformers
+        key: ${{ runner.os }}-st-3.13-${{ hashFiles('requirements.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-st-3.13-
+          ${{ runner.os }}-st-
     - name: Install dependencies
       run: make install
+    - name: Download sentence-transformer model
+      run: python -c "from sentence_transformers import SentenceTransformer; SentenceTransformer('sentence-transformers/paraphrase-MiniLM-L3-v2')"
     - name: Lint with flake8
       run: make lint
     - name: Test with pytest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:alpine
+FROM python:3.13-alpine
 
 WORKDIR /app
 COPY requirements.txt ./

--- a/README.md
+++ b/README.md
@@ -37,12 +37,13 @@ Note: the autosuggest trie is refreshed every 30 seconds.
 
 Prerequisites for developing:
 
-* Python/Pip
+* Python 3.13 / Pip
 
 Create a virtual environment
 
 ```
 python -m venv .venv
+source .venv/bin/activate
 ```
 
 Install requirements


### PR DESCRIPTION
## Summary
- switch project tooling to Python 3.13
- cache sentence-transformer model in CI and pre-download it
- document activating the virtual environment before installing deps

## Testing
- `make lint`
- `make test` *(fails: selenium.common.exceptions.NoSuchDriverException: Unable to obtain driver for chrome)*

------
https://chatgpt.com/codex/tasks/task_e_68982fe56690832488ce19e3a5902e08